### PR TITLE
fix: address already in use

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "cors": "^2.8.5",
     "express": "^4.21.1",
     "express-http-proxy": "^2.1.1",
+    "get-port-please": "^3.1.2",
     "http-proxy-middleware": "^3.0.3",
     "pathe": "^1.1.2",
     "picocolors": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       express-http-proxy:
         specifier: ^2.1.1
         version: 2.1.1
+      get-port-please:
+        specifier: ^3.1.2
+        version: 3.1.2
       http-proxy-middleware:
         specifier: ^3.0.3
         version: 3.0.3
@@ -4313,6 +4316,10 @@ packages:
       has-proto: 1.0.3
       has-symbols: 1.0.3
       hasown: 2.0.2
+
+  /get-port-please@3.1.2:
+    resolution: {integrity: sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ==}
+    dev: false
 
   /get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -17,7 +17,7 @@ export interface DevOpts {
 export async function dev(opts: DevOpts) {
   const port = opts.port || DEFAULT_PORT;
   const _port = await getPort(port);
-  const hmrPort = _port + 1;
+  const hmrPort = await getPort(_port + 1);
   const host = opts.host || 'localhost';
 
   await createServer({

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -1,4 +1,5 @@
 import type { BuildParams } from '@umijs/mako';
+import { getPort } from 'get-port-please';
 import { build } from './build';
 import { DEFAULT_PORT } from './constants';
 import { createServer } from './fishkit/server';
@@ -15,11 +16,12 @@ export interface DevOpts {
 
 export async function dev(opts: DevOpts) {
   const port = opts.port || DEFAULT_PORT;
-  const hmrPort = port + 1;
+  const _port = await getPort(port);
+  const hmrPort = _port + 1;
   const host = opts.host || 'localhost';
 
   await createServer({
-    port,
+    port: _port,
     hmrPort,
     host,
     https: opts.https,


### PR DESCRIPTION
修复开发端口被占用问题
```bash
➜  normal git:(master) ✗ pnpm dev

> @examples/normal@ dev /Users/congxiaochen/Documents/tnf/examples/normal
> tnf dev

♻️  Generating routes...
node:events:492
      throw er; // Unhandled 'error' event
      ^

Error: listen EADDRINUSE: address already in use :::8000
    at Server.setupListenHandle [as _listen2] (node:net:1872:16)
    at listenInCluster (node:net:1920:12)
    at Server.listen (node:net:2008:7)
    at createServer (/Users/congxiaochen/Documents/tnf/dist/fishkit/server.js:95:10)
    at dev (/Users/congxiaochen/Documents/tnf/dist/dev.js:35:40)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
Emitted 'error' event on Server instance at:
    at emitErrorNT (node:net:1899:8)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  code: 'EADDRINUSE',
  errno: -48,
  syscall: 'listen',
  address: '::',
  port: 8000
}

Node.js v20.10.0
 ELIFECYCLE  Command failed with exit code 1.
```