### PR TITLE
Optimize TypeScript Support for CSS Modules

### DIFF
--- a/src/sync/write_types.ts
+++ b/src/sync/write_types.ts
@@ -14,12 +14,12 @@ function checkTsconfig(content: string) {
   }
 }
 
-async function installTypescriptPluginCssModules(context: { cwd: string }) {
+function installTypescriptPluginCssModules(context: { cwd: string }) {
   const pm = new PackageManager({ cwd: context.cwd });
-  pm.addDevDeps({ 'typescript-plugin-css-modules': '^5.1.0' });
 
-  await pm.installDeps().catch(() => {
-    throw new Error('Failed to install typescript-plugin-css-modules');
+  pm.installSpecifiedDeps({
+    pkg: 'typescript-plugin-css-modules@^5.1.0',
+    isDev: true,
   });
 }
 
@@ -67,7 +67,7 @@ export async function writeTypes({ context }: SyncOptions) {
   const userTsconfigPath = path.join(cwd, 'tsconfig.json');
   checkTsconfig(fs.readFileSync(userTsconfigPath, 'utf-8'));
 
-  await installTypescriptPluginCssModules(context);
+  installTypescriptPluginCssModules(context);
 
   const tsconfigPath = path.join(tmpPath, 'tsconfig.json');
   const paths = generatePathsFromAlias(tmpPath, config.alias || []);


### PR DESCRIPTION
<!-- Your PR description here -->

## 优化 CSS Modules 的 TypeScript 类型支持

### 解决方案
1. 在 write_types 执行阶段安装 typescript-plugin-css-modules 依赖
2. 优化 PackageManager,新增方法支持安装指定依赖,避免循环调用问题
* 之前的 install 方法会触发 postinstall -> sync -> install 的循环
* 新增专门的方法用于安装单个依赖包
4. 在 tsconfig.json 中添加插件配置

## Optimize TypeScript Support for CSS Modules

### Solution

1. Install typescript-plugin-css-modules dependency during write_types execution
2. Optimize PackageManager by adding method to install specific dependencies, avoiding circular calls:
 * Previous install method triggered postinstall -> sync -> install loop
 * Add dedicated method for single package installation
4. Add plugin configuration in tsconfig.json


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [ ] Run the tests and other checks with `pnpm ci`

### Changesets

- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features and fix bugs should all be `patch` before we release `0.1.0`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
