### PR TITLE
feat(router): add simplified route generation option

### DIFF
--- a/.changeset/kind-carrots-retire.md
+++ b/.changeset/kind-carrots-retire.md
@@ -1,0 +1,5 @@
+---
+'@umijs/tnf': patch
+---
+
+feat(router): add simplified route generation option

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /examples/*/node_modules
 /create-tnf/node_modules
 /create-tnf/dist
+.DS_Store

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -72,6 +72,7 @@ export const ConfigSchema = z.object({
         ])
         .optional(),
       convention: RouterGeneratorConfig,
+      simplifyRoute: z.boolean().optional(),
     })
     .optional(),
   ssr: z.object({}).optional(),

--- a/src/generate/generate_route.ts
+++ b/src/generate/generate_route.ts
@@ -1,0 +1,523 @@
+import { promises as fsp } from 'fs';
+import * as path from 'path';
+import { join } from 'pathe';
+
+let rootRoute: RouteInfo | null = null;
+
+// 不需要生成path的route
+const NOT_NEED_PATH = Symbol('NOT_NEED_PATH');
+
+interface BaseRouteInfo {
+  filePath: string;
+  importPath: string;
+  routeName: string;
+  isRoot: boolean;
+  isIndex: boolean;
+  isLayout: boolean;
+  isLayoutIndependent: boolean;
+  isSplat: boolean;
+  routeSegments: string[];
+}
+
+interface RouteInfo extends BaseRouteInfo {
+  routePath: string | null;
+  // 为了方便生成createRoute
+  parentRoute: RouteInfo | null;
+}
+
+interface RouteInfoTree extends RouteInfo {
+  childrenRoute: RouteInfoTree[];
+}
+
+interface GeneratorOptions {
+  baseDir: string;
+  srcDir?: string;
+}
+
+const removeExt = (path: string) => {
+  return path.replace(/\.[^/.]+$/, '');
+};
+
+const convertPathToName = (pathArray: string[]) => {
+  return pathArray.map((part: string) => {
+    // 检查是否为文件名（包含扩展名）
+    let str = part;
+    if (part.includes('.tsx') || part.includes('.jsx')) {
+      const parts = part.split('.');
+      parts.pop();
+      str = parts.join('');
+    }
+    return (
+      str
+        // 处理 _前缀
+        .replace(/^_(.)/g, (_, c) => c.toUpperCase())
+        // // 处理 _后缀
+        // .replace(/_$/g, '')
+        // 处理中间的_
+        .replace(/(_)(.)/g, (_, __, c) => c.toUpperCase())
+        // // 处理 $前缀
+        // .replace(/^\$(.)/g, (_, c) => c.toUpperCase())
+        // 处理连字符
+        .replace(/-(.)/g, (_, c) => c.toUpperCase())
+        // 处理括号
+        .replace(/[()]/g, '')
+        // 确保首字母大写
+        .replace(/^(.)/, (c) => c.toUpperCase())
+    );
+  });
+};
+
+const getImportPath = (
+  filePath: string,
+  baseDir: string,
+  srcDir: string,
+): string => {
+  return path
+    .join(srcDir, path.relative(baseDir, filePath))
+    .replace(/\\/g, '/');
+};
+
+const generateRouteName = (segments: string[]): string => {
+  const base = convertPathToName(segments).join('');
+  return `${base}Import`;
+};
+
+const processRootRoute = (
+  filePath: string,
+  baseDir: string,
+  srcDir: string,
+): RouteInfo => ({
+  filePath,
+  importPath: getImportPath(filePath, baseDir, srcDir),
+  routeName: 'rootRouteImport',
+  routePath: '/',
+  parentRoute: null,
+  isRoot: true,
+  isIndex: false,
+  isLayout: false,
+  isLayoutIndependent: false,
+  isSplat: false,
+  routeSegments: ['__root.tsx'],
+});
+
+const getRouteType = (
+  filePath?: string,
+): {
+  isIndex: boolean;
+  isSplat: boolean;
+  isLayoutIndependent: boolean;
+  isLayout: boolean;
+  isGroup: boolean;
+  isRoot: boolean;
+} => {
+  const isIndex = filePath === 'index';
+  const isSplat = filePath === '$';
+  const isLayoutIndependent = filePath?.endsWith('_') || false;
+  const isLayout = filePath?.startsWith('_') || false;
+  const isGroup =
+    (filePath?.startsWith('(') && filePath?.endsWith(')')) || false;
+  const isRoot = filePath === '__root';
+
+  return {
+    isIndex,
+    isSplat,
+    isLayoutIndependent,
+    isLayout,
+    isGroup,
+    isRoot,
+  };
+};
+
+const parseRouteInfo = (
+  segments: string[],
+  filePath: string,
+  baseDir: string,
+  srcDir: string,
+): BaseRouteInfo => {
+  const routeName = generateRouteName(segments);
+  const { isIndex, isSplat, isLayoutIndependent, isLayout } = getRouteType(
+    segments[segments.length - 1],
+  );
+
+  return {
+    filePath,
+    importPath: getImportPath(filePath, baseDir, srcDir),
+    routeName,
+    isRoot: false,
+    isIndex,
+    isLayout,
+    isLayoutIndependent,
+    isSplat,
+    routeSegments: segments,
+  };
+};
+
+const fileNameToSegments = (filename: string): string[] | null => {
+  // 忽略以 . 或 - 开头的文件
+  if (filename.startsWith('.') || filename.startsWith('-')) {
+    return null;
+  }
+
+  // 获取文件扩展名
+  const ext = /\.(tsx|jsx)$/.exec(filename)?.[0];
+  if (!ext) {
+    return null;
+  }
+
+  // 首先处理连续的点号
+  let processedName = filename.replace(/\.{2,}/g, '.');
+
+  // 然后移除扩展名
+  let name = processedName.slice(0, -ext.length);
+
+  // 如果没有点号，说明是普通文件名
+  if (!name.includes('.')) {
+    return [processedName];
+  }
+
+  // 将点号分割 把扩展名加回去
+  const segments = name.split('.');
+  segments[segments.length - 1] = segments[segments.length - 1] + ext;
+  return segments;
+};
+
+const processFile = async (
+  filePath: string,
+  baseDir: string,
+  srcDir: string,
+): Promise<BaseRouteInfo | null> => {
+  const relativePath = path.relative(baseDir, filePath);
+  const parsedPath = path.parse(relativePath);
+
+  // 不允许文件作为路由组
+  if (getRouteType(parsedPath.name).isGroup) {
+    throw new Error(`this file ${parsedPath.name} is not supported`);
+  }
+
+  const baseSegments = fileNameToSegments(parsedPath.base);
+  if (!baseSegments) return null;
+  const routeSegments = parsedPath.dir.split(path.sep).concat(baseSegments);
+
+  // 如果第一个元素为空，代表路径为 baseDir/xxx.tsx
+  if (routeSegments[0] === '') {
+    routeSegments.shift();
+  }
+
+  if (parsedPath.name === '__root') {
+    rootRoute = processRootRoute(filePath, baseDir, srcDir);
+    return rootRoute;
+  }
+
+  return parseRouteInfo(routeSegments, filePath, baseDir, srcDir);
+};
+
+const scanDirectory = async (
+  dir: string,
+  baseDir: string,
+  srcDir: string,
+): Promise<BaseRouteInfo[]> => {
+  const entries = await fsp.readdir(dir, { withFileTypes: true });
+  const routesPromises = entries.map(async (entry) => {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      return await scanDirectory(fullPath, baseDir, srcDir);
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.tsx')) {
+      const baseRoute = await processFile(fullPath, baseDir, srcDir);
+      return baseRoute ? [baseRoute] : [];
+    }
+
+    return [];
+  });
+
+  const routeArrays = (await Promise.all(routesPromises)).flat();
+  return routeArrays;
+};
+
+type BaseRouteInfoWithParent = BaseRouteInfo & {
+  parentRoute: BaseRouteInfo | null;
+};
+
+const determineParentRoute = (
+  baseRoutes: BaseRouteInfo[],
+  route: BaseRouteInfo,
+): BaseRouteInfoWithParent => {
+  if (route.routeSegments.length === 1) {
+    if (route.isRoot) {
+      return {
+        ...route,
+        parentRoute: null,
+      };
+    }
+    return {
+      ...route,
+      parentRoute: rootRoute,
+    };
+  }
+
+  // 倒序遍历routeSegments
+  for (let i = route.routeSegments.length - 1; i >= 0; i--) {
+    const currentSegments = route.routeSegments.slice(0, i);
+    const lastSegment = currentSegments[currentSegments.length - 1];
+
+    //  Non-Nested Routes 不能作为父路由 直接跳过
+    const { isLayoutIndependent } = getRouteType(lastSegment);
+    if (isLayoutIndependent) {
+      continue;
+    }
+
+    const parentRoute = baseRoutes.find(
+      (r) =>
+        r.routeSegments.join('/') === currentSegments.join('/') + '.tsx' ||
+        r.routeSegments.join('/') === currentSegments.join('/') + '.jsx',
+    );
+    if (parentRoute) {
+      return {
+        ...route,
+        parentRoute,
+      };
+    }
+  }
+
+  // 没有任何匹配的情况
+  return {
+    ...route,
+    parentRoute: rootRoute,
+  };
+};
+
+// 获取两个路由的差异segment
+const getSegmentsDiff = (
+  routeSegments: string[],
+  parentRouteSegments: string[],
+): string[] => {
+  const diffSegments: string[] = [];
+  // 需要注意的是，父路由的最后一个segment是文件，会多一个文件后缀
+  for (let i = 0; i < routeSegments.length; i++) {
+    const currentSegment = routeSegments[i];
+    // ts 这里会报错 因为routeSegments[i] 可能为空
+    if (!currentSegment) continue;
+    if (currentSegment !== removeExt(parentRouteSegments[i] || '')) {
+      diffSegments.push(removeExt(currentSegment));
+    }
+  }
+  return diffSegments;
+};
+
+const normalizeSegment = (segment: string) => {
+  // 将后缀_去掉
+  return segment.replace(/_$/, '');
+};
+
+const generateRoutePath = (
+  baseRoutes: BaseRouteInfoWithParent[],
+): RouteInfo[] => {
+  const existRoute: string[] = [];
+
+  // 在生成path时，要注意有一些特殊的路由要特别注意
+  // 1. layoutIndependent_ 它不会作为父路由，但是在path中又需要包含这个父路由的path
+  // 2. _layout 无路由路由，要生成path时，需要跳过它
+  // 3. (group) 路由组，在生成path时需要去掉路由组，不作为path
+  // 4. index 在生成path时，直接做为 /
+
+  return baseRoutes.map((route) => {
+    const { parentRoute, routeSegments, routeName } = route;
+
+    const { isLayout, isRoot } = getRouteType(
+      routeSegments[routeSegments.length - 1],
+    );
+    if (isLayout || isRoot) {
+      return {
+        ...route,
+        routePath: null,
+      } as RouteInfo;
+    }
+
+    if (existRoute.includes(routeName)) {
+      throw new Error(`routeName ${routeName} is duplicated`);
+    }
+
+    existRoute.push(routeName);
+
+    const diffSegments = getSegmentsDiff(
+      routeSegments,
+      parentRoute!.routeSegments,
+    );
+
+    let routePathSegments: string[] = [];
+
+    // 不能直接拿最后一个segment来决定路由 因为可能存在layoutIndependent_.tsx这种文件
+    for (const [index, segment] of diffSegments.entries()) {
+      const { isGroup, isRoot, isIndex, isLayout } = getRouteType(segment);
+      if (isGroup || isLayout || isRoot) continue;
+      // 特别注意 index ，因为index作为文件的时候 作为/
+      // 但是如果index作为文件夹，就要直接视为 /index/
+      if (isIndex) {
+        if (index === diffSegments.length - 1) {
+          if (routePathSegments.length === 0) {
+            routePathSegments.push('/');
+          }
+        } else {
+          routePathSegments.push('index');
+        }
+        continue;
+      }
+      routePathSegments.push(normalizeSegment(segment));
+    }
+
+    return {
+      ...route,
+      routePath: routePathSegments.join('/'),
+    } as RouteInfo;
+  });
+};
+
+// 将baseRoute转换为Route 主要是要确定parentRoute和path
+const baseRoutesToRoutes = (baseRoutes: BaseRouteInfo[]): RouteInfo[] => {
+  const BaseRoutesWithParent = baseRoutes.map((route) =>
+    determineParentRoute(baseRoutes, route),
+  );
+  const routes = generateRoutePath(BaseRoutesWithParent);
+  return routes;
+};
+
+const generateImports = (routes: RouteInfo[]): string[] => {
+  return [
+    "import { createRootRoute, createRoute } from '@tanstack/react-router'",
+    '',
+    ...routes.map(
+      (route) => `import ${route.routeName} from '${route.importPath}'`,
+    ),
+  ];
+};
+
+const generateRouteDefinitions = (routes: RouteInfo[]): string[] => {
+  const getComponentName = (route: RouteInfo): string =>
+    route.routeName.replace(/Import$/, 'Component');
+
+  return routes.map((route) => {
+    if (route.isRoot) {
+      return [
+        `const ${getComponentName(route)} = createRootRoute({`,
+        `  component: ${route.routeName}`,
+        `})`,
+      ].join('\n');
+    }
+
+    const definition = [
+      `const ${getComponentName(route)} = createRoute({`,
+      `  getParentRoute: () => ${getComponentName(route.parentRoute!)},`,
+      `  component: ${route.routeName},`,
+    ];
+
+    if (!route.isLayout) {
+      definition.push(`  path: '${route.routePath}',`);
+    } else {
+      definition.push(`  id: '${route.routePath}',`);
+    }
+
+    definition.push('})');
+
+    return definition.join('\n');
+  });
+};
+
+const generateRouteTree = (routes: RouteInfo[]): RouteInfoTree => {
+  // rootRoute 已经在前面判断了 没有会直接抛出异常
+  const rootRoute = routes.find((r) => r.isRoot)!;
+
+  // 构造哈希图 方便快速查找
+  const hashMap: Record<string, RouteInfoTree> = {};
+  routes.forEach((route) => {
+    hashMap[route.routeName] = {
+      ...route,
+      childrenRoute: [],
+    };
+  });
+
+  routes.forEach((route) => {
+    if (route.isRoot) return;
+    const parentRoute = hashMap[route.parentRoute!.routeName]!;
+    parentRoute.childrenRoute.push(hashMap[route.routeName]!);
+  });
+
+  return hashMap[rootRoute.routeName]!;
+};
+
+function generateRouteTreeCode(routeInfo: RouteInfoTree): string {
+  const getComponentName = (route: RouteInfo): string =>
+    route.routeName.replace(/Import$/, 'Component');
+
+  function processRouteTree(route: RouteInfoTree): string {
+    // 获取路由变量名
+    const routeVarName = getComponentName(route);
+
+    // 如果有子路由，生成带 addChildren 的代码
+    if (route.childrenRoute && route.childrenRoute.length > 0) {
+      const childrenCode = route.childrenRoute
+        .map((child) => processRouteTree(child))
+        .filter(Boolean) // 过滤掉空值
+        .join(',\n  ');
+
+      return `${routeVarName}.addChildren([\n  ${childrenCode}\n])`;
+    }
+
+    // 没有子路由，直接返回路由变量名
+    return routeVarName;
+  }
+
+  // 生成最终的路由树代码
+  return `export const routeTree = ${processRouteTree(routeInfo)}`;
+}
+
+const generateRouterCode = (routes: RouteInfo[]): string => {
+  const imports = generateImports(routes);
+  const routeDefinitions = generateRouteDefinitions(routes);
+  const routeTree = generateRouteTree(routes);
+  const routeTreeCode = generateRouteTreeCode(routeTree);
+  return [
+    imports.join('\n'),
+    '',
+    routeDefinitions.join('\n\n'),
+    '',
+    routeTreeCode,
+  ].join('\n');
+};
+
+export const generateTanStackRouter = async ({
+  baseDir,
+  srcDir = './../src/pages',
+}: GeneratorOptions): Promise<string> => {
+  try {
+    const baseRoutesArray = await scanDirectory(baseDir, baseDir, srcDir);
+    if (!rootRoute) throw new Error('rootRoute not found');
+    const routes = baseRoutesToRoutes(baseRoutesArray);
+    return generateRouterCode(routes);
+  } catch (error) {
+    console.error('Error generating router code:', error);
+    throw error;
+  }
+};
+
+export const generateRoute = async ({
+  generatedRouteTree,
+  routeTreeFileHeader,
+}: {
+  generatedRouteTree: string;
+  routeTreeFileHeader: string[];
+}) => {
+  try {
+    const routerCode = await generateTanStackRouter({
+      baseDir: 'src/pages',
+    });
+    await fsp.writeFile(
+      generatedRouteTree,
+      [...routeTreeFileHeader, routerCode].join('\n'),
+    );
+    console.log('Router code generated successfully!');
+  } catch (error) {
+    console.error('Failed to generate router code:', error);
+  }
+};

--- a/src/sync/write_route_tree.ts
+++ b/src/sync/write_route_tree.ts
@@ -1,5 +1,6 @@
 import { type Config, generator } from '@tanstack/router-generator';
 import path from 'pathe';
+import { generateRoute } from '../generate/generate_route';
 import type { SyncOptions } from './sync';
 
 export async function writeRouteTree({ context }: SyncOptions) {
@@ -10,29 +11,41 @@ export async function writeRouteTree({ context }: SyncOptions) {
   } = context;
   const { router } = config;
 
-  await generator({
-    routeFileIgnorePrefix: '-',
-    routesDirectory: path.join(cwd, 'src/pages'),
-    generatedRouteTree: path.join(tmpPath, 'routeTree.gen.ts'),
-    quoteStyle: 'single',
-    semicolons: false,
-    disableTypes: false,
-    addExtensions: false,
-    disableLogging: false,
-    disableManifestGeneration: false,
-    apiBase: '/api',
-    routeTreeFileHeader: [
-      '/* prettier-ignore-start */',
-      '/* eslint-disable */',
-      '// @ts-nocheck',
-      '// noinspection JSUnusedGlobalSymbols',
-    ],
-    routeTreeFileFooter: ['/* prettier-ignore-end */'],
-    indexToken: 'index',
-    routeToken: 'route',
-    experimental: {
-      enableCodeSplitting: true,
-    },
-    ...(router?.convention || {}),
-  } as Config);
+  if (router?.simplifyRoute) {
+    await generateRoute({
+      generatedRouteTree: path.join(tmpPath, 'routeTree.gen.ts'),
+      routeTreeFileHeader: [
+        '/* prettier-ignore-start */',
+        '/* eslint-disable */',
+        '// @ts-nocheck',
+        '// noinspection JSUnusedGlobalSymbols',
+      ],
+    });
+  } else {
+    await generator({
+      routeFileIgnorePrefix: '-',
+      routesDirectory: path.join(cwd, 'src/pages'),
+      generatedRouteTree: path.join(tmpPath, 'routeTree.gen.ts'),
+      quoteStyle: 'single',
+      semicolons: false,
+      disableTypes: false,
+      addExtensions: false,
+      disableLogging: false,
+      disableManifestGeneration: false,
+      apiBase: '/api',
+      routeTreeFileHeader: [
+        '/* prettier-ignore-start */',
+        '/* eslint-disable */',
+        '// @ts-nocheck',
+        '// noinspection JSUnusedGlobalSymbols',
+      ],
+      routeTreeFileFooter: ['/* prettier-ignore-end */'],
+      indexToken: 'index',
+      routeToken: 'route',
+      experimental: {
+        enableCodeSplitting: true,
+      },
+      ...(router?.convention || {}),
+    } as Config);
+  }
 }


### PR DESCRIPTION
<!-- Your PR description here -->
# 更加简单的路由

要使一个组件有路由功能，需要导出一个 `createFileRoute()`，因为目前选择的是 Tanstack Router 的 File-Based Routing. 虽然这一部分可以通过generate生成，但是如果碰到嵌套路由，使用这个命令就会有点反直觉，因此我的预期目标为：尽量不让这部分代码出现在组件文件内，示例代码如下：

```tsx
// src/pages/foo/bar.tsx

export default function Bar() {
  const { users } = useLoaderData({
    from: '/foo/bar',
  });
  return (
    <div>
      <h3>Welcome Foo!</h3>
      <p>Users</p>
      <ul>
        {users.map((user: any) => (
          <li key={user.id}>{user.firstName}</li>
        ))}
      </ul>
    </div>
  );
}

// src/.tnf/routeTree.gen.ts

import { createRootRoute, createRoute } from '@tanstack/react-router'
import rootRouteImport from '../src/pages/__root.tsx'
import FooBarImport from '../src/pages/foor/bar.tsx'

const rootRouteComponent = createRootRoute({
  component: rootRouteImport
})

const FooBarComponent = createRoute({
  getParentRoute: () => rootRouteComponent,
  component: FooBarImport,
  path: '/foo/bar',
})

```

要达到这一目标，可以使用 Code-Based Routing ，在 TanStack Router 的官网里有写到：

> Code-based routing is no different from file-based routing in that it uses the same route tree concept to organize, match and compose matching routes into a component tree. The only difference is that instead of using the filesystem to organize your routes, you use code.
>
> Believe it or not, file-based routing is really a superset of code-based routing and uses the filesystem and a bit of code-generation abstraction on top of it to generate this structure you see above automatically.

因此，完全可以使用 Code-Based Routing 来替代 File-Based Routing 实现 TNF 中的路由功能，并简化路由。

只需按照 TanStack Router 的 File-Based Routing 路由规范（ Code-Based Routing 和  File-Based Routing 的路由规范有差别，这里以  File-Based Routing 为准），实现路由路线的解析，生成一个符合 File-Based Routing 规范的路由路线，就可以平替原来的 generator 以自动生成 `routeTree.gen.ts` 。

本PR实现了路由生成的功能（如果这个方案ok的话，后面补充example和测试用例），但是缺少路由配置的功能，原因有两点：

1. 不确定实现简化路由的 feature 这样做是否 ok
2. 对于如何确定组件是否有导出 `RouteConfig` ，暂时没有确定的方案，可能要用 babel 或者 typescript 解析文件，不知道该用哪个方案比较好

路由配置的 feature 预期如下：

```tsx
// src/pages/foo/bar.tsx

export const RouteConfig = {
  loader: () => {}
}

export default function Bar() {
  const { users } = useLoaderData({
    from: '/foo/bar',
  });
  return (
    <div>
      <h3>Welcome Foo!</h3>
      <p>Users</p>
      <ul>
        {users.map((user: any) => (
          <li key={user.id}>{user.firstName}</li>
        ))}
      </ul>
    </div>
  );
}

```


下面举一个例子，例子里尽可能覆盖了可能情况：

```
routes/
├── __root.tsx
├── index.tsx
├── about.tsx
├── posts.tsx
├── posts/
│   ├── index.tsx
│   ├── $postId.tsx
├── posts_/
│   ├── $postId
│   ├── ├── edit.tsx
├── posts.$postId.detail.tsx
├── settings/
│   ├── $type.tsx
│   ├── info.tsx
├── settings_.modify.tsx
├── _layout.tsx
├── _layout/
│   ├── layout-a.tsx
├── ├── layout-b.tsx   
├── files/
│   ├── $.tsx
├── splat/
│   ├── $.tsx
│   ├── $id.tsx
├── splat2/
│   ├── $.tsx
│   ├── ├── test.tsx
│   ├── $
│   ├── $id.tsx
├── splat3/
│   ├── $.tsx
│   ├── ├── test2.tsx
│   ├── $
│   ├── $id
│   ├── ├── test3.tsx
│   ├── $id.tsx
├── (auth)/
│   ├── login.tsx
│   ├── register.tsx
├── (auth).tsx (throw error, invaild route)
```

生成出来的代码：

```tsx
import { createRootRoute, createRoute } from '@umijs/tnf/router';

import { Route as RootImport } from './../src/pages/__root'
import { Route as AboutImport } from './../src/pages/index'
import { Route as AboutImport } from './../src/pages/about'
import { Route as PostsImport } from './../src/pages/posts'
// ... 省略导入

// path: / , output: <Root>
const rootRoute = createRootRoute({
	component: RootImport
})

// path: / , output: <Root><RootIndex>
const indexRoute = createRoute({
  getParentRoute: () => rootRoute,
  path: '/',
  component: IndexComponet
})

// path: /about , output: <Root><About>
const aboutRoute = createRoute({
  getParentRoute: () => rootRoute,
  path: 'about',
  component: AboutImport
})

// 从这里开始，接下来的createRoute省略了component，除了pathless 路由，component是必须要配置的
// path: /posts, output: <Root><Posts>
const postsRoute = createRoute({
  getParentRoute: () => rootRoute,
  path: 'posts',
})

// path: /posts, output: <Root><Posts><PostsIndex>
const postsIndexRoute = createRoute({
  getParentRoute: () => postsRoute,
  path: '/',
})

//path: /posts/$, output: <Root><Posts><Post>
const postRoute = createRoute({
  getParentRoute: () => postsRoute,
  path: '$postId',
})

//path: /posts/$/edit, output: <Root><PostEditor>
const postEditorRoute = createRoute({
  getParentRoute: () => rootRoute,
  path: 'posts/$postId/edit',
})

//path: /posts/$/detail, output: <Root><Posts><Post><PostDetail>
const postDetailRoute = createRoute({
  getParentRoute: () => postRoute,
  path: 'detail',
})

// 最终需要生成的结果（忽略除了posts以外的路由）
const routeTree = rootRoute.addChildren([
  // The post editor route is nested under the root route
  postEditorRoute,
  postsRoute.addChildren([postRoute.addChildren(postDetailRoute)]),
])

// 在本例子中，Settings.tsx 不存在，因此跳过了渲染 <Settings>
// path: /settings/$, output: <Root><Settings>
const settingsRoute = createRoute({
  getParentRoute: () => rootRoute,
  path: '/settings/$type',
})

// path: /settings/info, output: <Root><SettingsInfo>
const notificationsRoute = createRoute({
  getParentRoute: () => rootRoute,
  path: '/settings/info',
})

// 以下划线(_) 为前缀的路由被视为 "无路径 "路由，用于用附加组件和逻辑封装子路由，而无需在 URL 中提供匹配路径
const layoutRoute = createRoute({
  getParentRoute: () => rootRoute,
  id: 'layout',
})

// path: /layout-a, output: <Root><Layout><LayoutA>
const layoutARoute = createRoute({
  getParentRoute: () => layoutRoute,
  path: 'layout-a',
})

// Layout -> LayoutIndenpendent -> Normal
parentRoute: Layout
path: 

// path: /layout-b, output: <Root><Layout><LayoutB>
const layoutBRoute = createRoute({
  getParentRoute: () => layoutRoute,
  path: 'layout-b',
})

// 这是 splat 路由
// 存在向后兼容的问题，详见 https://tanstack.com/router/latest/docs/framework/react/guide/routing-concepts#splat--catch-all-routes
// url path 为 files/* 时，获取到的param为{ _splat: $ }（*指代有效字符串）
// path: /files/*, output: <Root><Files>
const filesRoute = createRoute({
  getParentRoute: () => rootRoute,
  path: 'files/$',
})

// 当存在 $ 和 $param 的情况时 （*指代有效字符串）
// url path 为 splat/* 时，会渲染splatIdRoute
// url path 为 splat/ 时，会渲染splatRoute
// path: /splat, output: <Root><Splat>
const splatRoute = createRoute({
  getParentRoute: () => rootRoute,
  path: 'splat/$',
})

// path: /splat/*, output: <Root><SplatId> （*指代有效字符串）
const splatIdRoute = createRoute({
  getParentRoute: () => rootRoute,
  path: 'splat/$id',
})

// 当存在 $ 和 $param 的情况时，且 $.tsx 和 $param.tsx 都实现的情况下
// $param 的优先级更高，此时就要渲染结果可以看下面两个例子

// 1. $param 目录下没有实现路由 请看代码块里的目录 splat2
// url path 为 splat2/$/test 时，会渲染 <Root><NotFound> 
// url path 为 splat/$ 时，会渲染 <Root><$Param>
// 解释：此时 $param 覆盖了 $，即使想访问已存在的 $/test ，是不存在的，因为路径匹配的是 $param/test
// 可是此时 $param 目录下没有 test.tsx

const splat2Route = createRoute({
  getParentRoute: () => rootRoute,
  path: 'splat2/$',
})

const splat2TestRoute = createRoute({
  getParentRoute: () => $Route,
  path: 'splat2/$/test',
})

// 这个path优先级更高
const splat2IdRoute = createRoute({
  getParentRoute: () => rootRoute,
  path: 'splat/$',
})

// 2. $param 目录下有实现路由 请看代码块里的目录 splat3 （*指代有效字符串）
// url path 为 splat3/*/test2 时，会渲染 <Root><$Param><NotFound>
// url path 为 splat3/*/test3 时，会渲染 <Root><$Param><Test3>
// url path 为 splat3/* 时，会渲染 <Root><$Param>
// 解释：此时 $param 覆盖了 $，即使想访问已存在的 $/test2 ，也是不存在的，因为路径匹配的是 $param/test
// 可是此时 $param 目录下没有 test2.tsx ，但是，此时相比于上一个例子会多渲染一个 <$Param>

const splat3Route = createRoute({
  getParentRoute: () => rootRoute,
  path: 'splat3/$',
})

const splat3Test2Route = createRoute({
  getParentRoute: () => $Route,
  path: 'splat3/$/test2',
})

const splat3IdRoute = createRoute({
  getParentRoute: () => rootRoute,
  path: 'splat/$id',
})

const splat3Test3Route = createRoute({
  getParentRoute: () => splat3IdRoute,
  path: 'splat3/$id/test3',
})

// 无路径路由组
// path: /login, output: <Root><Login>
const loginRoute = createRoute({
  getParentRoute: () => rootRoute,
  path: 'login',
})

// path: /login, output: <Root><Register>
const registerRoute = createRoute({
  getParentRoute: () => rootRoute,
  path: 'register',
})
```



---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests and other checks with `pnpm ci`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features and fix bugs should all be `patch` before we release `0.1.0`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
