### PR TITLE
feat(plugin-hooks): add watchChange hook

### DIFF
--- a/.changeset/selfish-worms-search.md
+++ b/.changeset/selfish-worms-search.md
@@ -1,0 +1,5 @@
+---
+'@umijs/tnf': patch
+---
+
+Add watchChange hook in Plugin

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -33,6 +33,15 @@ export const PluginSchema = z.object({
       z.union([z.string(), z.promise(z.string()), z.null()]),
     )
     .optional(),
+  watchChange: z
+    .function(
+      z.tuple([
+        z.string(),
+        z.object({ event: z.enum(['create', 'update', 'delete']) }),
+      ]),
+      z.void(),
+    )
+    .optional(),
 });
 
 export type Plugin = z.infer<typeof PluginSchema>;

--- a/src/watch/emitter.ts
+++ b/src/watch/emitter.ts
@@ -1,0 +1,38 @@
+import type { EventListener } from './types';
+
+export class WatchEmitter<T extends Record<string, (...args: any[]) => any>> {
+  private handlers: {
+    [K in keyof T]?: EventListener<T, K>[];
+  } = Object.create(null);
+
+  async close(): Promise<void> {}
+
+  emit<K extends keyof T>(
+    event: K,
+    ...args: Parameters<T[K]>
+  ): Promise<unknown> {
+    const listeners = this.handlers[event] || [];
+    return Promise.all(
+      listeners.map(async (handler) => await handler(...args)),
+    );
+  }
+
+  on<K extends keyof T>(event: K, listener: EventListener<T, K>): this {
+    if (!this.handlers[event]) {
+      this.handlers[event] = [];
+    }
+    this.handlers[event]!.push(listener);
+    return this;
+  }
+
+  off<K extends keyof T>(event: K, listener: EventListener<T, K>): this {
+    const listeners = this.handlers[event];
+    if (listeners) {
+      const index = listeners.indexOf(listener);
+      if (index !== -1) {
+        listeners.splice(index, 1);
+      }
+    }
+    return this;
+  }
+}

--- a/src/watch/fileWatcher.ts
+++ b/src/watch/fileWatcher.ts
@@ -1,0 +1,42 @@
+import chokidar, { FSWatcher } from 'chokidar';
+import type { ChangeEvent, ChokidarOptions } from './types';
+
+export class FileWatcher {
+  private watcher: FSWatcher;
+  private transformWatchers = new Map<string, FSWatcher>();
+
+  constructor(
+    private onChange: (id: string, event: ChangeEvent) => void,
+    private options: ChokidarOptions = {},
+  ) {
+    this.watcher = this.createWatcher();
+  }
+
+  watch(id: string): void {
+    this.watcher.add(id);
+  }
+
+  unwatch(id: string): void {
+    this.watcher.unwatch(id);
+    const transformWatcher = this.transformWatchers.get(id);
+    if (transformWatcher) {
+      transformWatcher.close();
+      this.transformWatchers.delete(id);
+    }
+  }
+
+  close(): void {
+    this.watcher.close();
+    for (const watcher of this.transformWatchers.values()) {
+      watcher.close();
+    }
+  }
+
+  private createWatcher(): FSWatcher {
+    return chokidar
+      .watch([], this.options)
+      .on('add', (id) => this.onChange(id, 'create'))
+      .on('change', (id) => this.onChange(id, 'update'))
+      .on('unlink', (id) => this.onChange(id, 'delete'));
+  }
+}

--- a/src/watch/types.ts
+++ b/src/watch/types.ts
@@ -1,0 +1,30 @@
+export type ChangeEvent = 'create' | 'update' | 'delete';
+
+export type ChokidarOptions = {
+  ignored?: string | RegExp | Array<string | RegExp>;
+  persistent?: boolean;
+  ignoreInitial?: boolean;
+  followSymlinks?: boolean;
+  cwd?: string;
+  disableGlobbing?: boolean;
+  usePolling?: boolean;
+  interval?: number;
+  binaryInterval?: number;
+  alwaysStat?: boolean;
+  depth?: number;
+  awaitWriteFinish?:
+    | boolean
+    | { stabilityThreshold?: number; pollInterval?: number };
+};
+
+export type WatchEvent =
+  | { code: 'START' }
+  | { code: 'CHANGE'; id: string; event: ChangeEvent }
+  | { code: 'ERROR'; error: Error }
+  | { code: 'END' };
+
+export type EventListener<T, K extends keyof T> = T[K] extends (
+  ...args: any[]
+) => any
+  ? (...args: Parameters<T[K]>) => void | Promise<void>
+  : never;

--- a/src/watch/watcher.ts
+++ b/src/watch/watcher.ts
@@ -1,0 +1,85 @@
+import { WatchEmitter } from './emitter';
+import { FileWatcher } from './fileWatcher';
+import type { ChangeEvent, ChokidarOptions, WatchEvent } from './types';
+
+export interface WatchOptions {
+  include?: string | RegExp | Array<string | RegExp>;
+  exclude?: string | RegExp | Array<string | RegExp>;
+  chokidar?: ChokidarOptions;
+}
+
+export class Watcher {
+  private fileWatcher: FileWatcher;
+  private emitter: WatchEmitter<{
+    event: (event: WatchEvent) => Promise<void>;
+    change: (path: string, details: { event: ChangeEvent }) => Promise<void>;
+    close: () => Promise<void>;
+  }>;
+  private closed = false;
+
+  constructor(options: WatchOptions = {}) {
+    this.emitter = new WatchEmitter();
+    this.fileWatcher = new FileWatcher(
+      (id, event) => this.handleChange(id, event),
+      options.chokidar,
+    );
+  }
+
+  watch(paths: string | string[]): void {
+    const pathArray = Array.isArray(paths) ? paths : [paths];
+    for (const path of pathArray) {
+      this.fileWatcher.watch(path);
+    }
+  }
+
+  on<E extends 'event' | 'change' | 'close'>(
+    event: E,
+    callback: E extends 'event'
+      ? (event: WatchEvent) => Promise<void>
+      : E extends 'change'
+        ? (id: string, details: { event: ChangeEvent }) => Promise<void>
+        : () => Promise<void>,
+  ): void {
+    this.emitter.on(event, callback as any);
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.fileWatcher.close();
+    await this.emitter.emit('close');
+  }
+
+  /**
+   * 提供两种层次的监听
+   *
+   * 1. event:统一处理所有类型的事件
+   * example:
+   * watcher.on('event', (event) => {
+   *  switch (event.code) {
+   *    case 'START':
+   *      console.log('Watch started');
+   *      break;
+   *    case 'CHANGE':
+   *      console.log(`File ${event.id} ${event.event}`);
+   *      break;
+   *    case 'ERROR':
+   *      console.error('Watch error:', event.error);
+   *      break;
+   *    case 'END':
+   *      console.log('Watch ended');
+   *      break;
+   *  }
+   * });
+   *
+   * 2. change:只关心文件变化
+   * example:
+   * watcher.on('change', (id, {event}) => {
+   *  console.log(`File ${id} ${event}`);
+   * });
+   */
+  private async handleChange(id: string, event: ChangeEvent): Promise<void> {
+    await this.emitter.emit('event', { code: 'CHANGE', id, event });
+    await this.emitter.emit('change', id, { event });
+  }
+}


### PR DESCRIPTION
<!-- Your PR description here -->
Instead of adding a watcher to the plugin context as originally suggested, I propose implementing a watchChange hook that better aligns with Rollup's plugin architecture.


---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [X] Run the tests and other checks with `pnpm ci`

### Changesets

- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features and fix bugs should all be `patch` before we release `0.1.0`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [X] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
